### PR TITLE
[MM] Update genmodel to enable control/uncontrol

### DIFF
--- a/plugins/fr.obeo.conference/model/conference.genmodel
+++ b/plugins/fr.obeo.conference/model/conference.genmodel
@@ -2,7 +2,7 @@
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/fr.obeo.conference/src" creationIcons="false"
     modelPluginID="fr.obeo.conference" modelName="Conference" importerID="org.eclipse.emf.importer.ecore"
-    complianceLevel="6.0" copyrightFields="false">
+    containmentProxies="true" complianceLevel="6.0" copyrightFields="false">
   <foreignModel>conference.ecore</foreignModel>
   <genPackages prefix="Conference" disposableProviderFactory="true" ecorePackage="conference.ecore#/">
     <genClasses ecoreClass="conference.ecore#//Conference">
@@ -46,7 +46,8 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute conference.ecore#//Location/name"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference conference.ecore#//Location/talks"/>
     </genClasses>
-    <nestedGenPackages prefix="MakingOf" disposableProviderFactory="true" ecorePackage="conference.ecore#//makingOf">
+    <nestedGenPackages prefix="MakingOf" basePackage="conference" disposableProviderFactory="true"
+        ecorePackage="conference.ecore#//makingOf">
       <genEnums typeSafeEnumCompatible="false" ecoreEnum="conference.ecore#//makingOf/Attitude">
         <genEnumLiterals ecoreEnumLiteral="conference.ecore#//makingOf/Attitude/serious"/>
         <genEnumLiterals ecoreEnumLiteral="conference.ecore#//makingOf/Attitude/cool"/>

--- a/plugins/fr.obeo.conference/src/conference/Conference.java
+++ b/plugins/fr.obeo.conference/src/conference/Conference.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.Conference#getTracks <em>Tracks</em>}</li>
  *   <li>{@link conference.Conference#getSpeakers <em>Speakers</em>}</li>
@@ -20,7 +21,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link conference.Conference#getDays <em>Days</em>}</li>
  *   <li>{@link conference.Conference#getLocations <em>Locations</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.ConferencePackage#getConference()
  * @model
@@ -38,7 +38,7 @@ public interface Conference extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Tracks</em>' containment reference list.
 	 * @see conference.ConferencePackage#getConference_Tracks()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Track> getTracks();
@@ -54,7 +54,7 @@ public interface Conference extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Speakers</em>' containment reference list.
 	 * @see conference.ConferencePackage#getConference_Speakers()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Person> getSpeakers();
@@ -96,7 +96,7 @@ public interface Conference extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Days</em>' containment reference list.
 	 * @see conference.ConferencePackage#getConference_Days()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Day> getDays();
@@ -112,7 +112,7 @@ public interface Conference extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Locations</em>' containment reference list.
 	 * @see conference.ConferencePackage#getConference_Locations()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Location> getLocations();

--- a/plugins/fr.obeo.conference/src/conference/Day.java
+++ b/plugins/fr.obeo.conference/src/conference/Day.java
@@ -13,11 +13,11 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.Day#getName <em>Name</em>}</li>
  *   <li>{@link conference.Day#getTalks <em>Talks</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.ConferencePackage#getDay()
  * @model

--- a/plugins/fr.obeo.conference/src/conference/Location.java
+++ b/plugins/fr.obeo.conference/src/conference/Location.java
@@ -13,11 +13,11 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.Location#getName <em>Name</em>}</li>
  *   <li>{@link conference.Location#getTalks <em>Talks</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.ConferencePackage#getLocation()
  * @model

--- a/plugins/fr.obeo.conference/src/conference/Person.java
+++ b/plugins/fr.obeo.conference/src/conference/Person.java
@@ -13,13 +13,13 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.Person#getTalks <em>Talks</em>}</li>
  *   <li>{@link conference.Person#getName <em>Name</em>}</li>
  *   <li>{@link conference.Person#getOrganisation <em>Organisation</em>}</li>
  *   <li>{@link conference.Person#getTracks <em>Tracks</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.ConferencePackage#getPerson()
  * @model

--- a/plugins/fr.obeo.conference/src/conference/Subject.java
+++ b/plugins/fr.obeo.conference/src/conference/Subject.java
@@ -11,11 +11,11 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.Subject#getDescription <em>Description</em>}</li>
  *   <li>{@link conference.Subject#isIsDone <em>Is Done</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.ConferencePackage#getSubject()
  * @model

--- a/plugins/fr.obeo.conference/src/conference/Talk.java
+++ b/plugins/fr.obeo.conference/src/conference/Talk.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.Talk#getSpeakers <em>Speakers</em>}</li>
  *   <li>{@link conference.Talk#getName <em>Name</em>}</li>
@@ -25,7 +26,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link conference.Talk#getLocation <em>Location</em>}</li>
  *   <li>{@link conference.Talk#getTime <em>Time</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.ConferencePackage#getTalk()
  * @model
@@ -139,7 +139,7 @@ public interface Talk extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Subjects</em>' containment reference list.
 	 * @see conference.ConferencePackage#getTalk_Subjects()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Subject> getSubjects();
@@ -155,7 +155,7 @@ public interface Talk extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Making Of Stories</em>' containment reference list.
 	 * @see conference.ConferencePackage#getTalk_MakingOfStories()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Story> getMakingOfStories();

--- a/plugins/fr.obeo.conference/src/conference/Track.java
+++ b/plugins/fr.obeo.conference/src/conference/Track.java
@@ -13,12 +13,12 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.Track#getTalks <em>Talks</em>}</li>
  *   <li>{@link conference.Track#getName <em>Name</em>}</li>
  *   <li>{@link conference.Track#getAnimators <em>Animators</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.ConferencePackage#getTrack()
  * @model
@@ -36,7 +36,7 @@ public interface Track extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Talks</em>' containment reference list.
 	 * @see conference.ConferencePackage#getTrack_Talks()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Talk> getTalks();

--- a/plugins/fr.obeo.conference/src/conference/impl/ConferenceImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/ConferenceImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.impl.ConferenceImpl#getTracks <em>Tracks</em>}</li>
  *   <li>{@link conference.impl.ConferenceImpl#getSpeakers <em>Speakers</em>}</li>
@@ -38,7 +39,6 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link conference.impl.ConferenceImpl#getDays <em>Days</em>}</li>
  *   <li>{@link conference.impl.ConferenceImpl#getLocations <em>Locations</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -129,7 +129,7 @@ public class ConferenceImpl extends EObjectImpl implements Conference {
 	 */
 	public EList<Track> getTracks() {
 		if (tracks == null) {
-			tracks = new EObjectContainmentEList<Track>(Track.class, this, ConferencePackage.CONFERENCE__TRACKS);
+			tracks = new EObjectContainmentEList.Resolving<Track>(Track.class, this, ConferencePackage.CONFERENCE__TRACKS);
 		}
 		return tracks;
 	}
@@ -141,7 +141,7 @@ public class ConferenceImpl extends EObjectImpl implements Conference {
 	 */
 	public EList<Person> getSpeakers() {
 		if (speakers == null) {
-			speakers = new EObjectContainmentEList<Person>(Person.class, this, ConferencePackage.CONFERENCE__SPEAKERS);
+			speakers = new EObjectContainmentEList.Resolving<Person>(Person.class, this, ConferencePackage.CONFERENCE__SPEAKERS);
 		}
 		return speakers;
 	}
@@ -174,7 +174,7 @@ public class ConferenceImpl extends EObjectImpl implements Conference {
 	 */
 	public EList<Day> getDays() {
 		if (days == null) {
-			days = new EObjectContainmentEList<Day>(Day.class, this, ConferencePackage.CONFERENCE__DAYS);
+			days = new EObjectContainmentEList.Resolving<Day>(Day.class, this, ConferencePackage.CONFERENCE__DAYS);
 		}
 		return days;
 	}
@@ -186,7 +186,7 @@ public class ConferenceImpl extends EObjectImpl implements Conference {
 	 */
 	public EList<Location> getLocations() {
 		if (locations == null) {
-			locations = new EObjectContainmentEList<Location>(Location.class, this, ConferencePackage.CONFERENCE__LOCATIONS);
+			locations = new EObjectContainmentEList.Resolving<Location>(Location.class, this, ConferencePackage.CONFERENCE__LOCATIONS);
 		}
 		return locations;
 	}

--- a/plugins/fr.obeo.conference/src/conference/impl/ConferencePackageImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/ConferencePackageImpl.java
@@ -556,19 +556,19 @@ public class ConferencePackageImpl extends EPackageImpl implements ConferencePac
 
 		// Initialize classes and features; add operations and parameters
 		initEClass(conferenceEClass, Conference.class, "Conference", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getConference_Tracks(), this.getTrack(), null, "tracks", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getConference_Speakers(), this.getPerson(), null, "speakers", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getConference_Tracks(), this.getTrack(), null, "tracks", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getConference_Speakers(), this.getPerson(), null, "speakers", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getConference_Name(), ecorePackage.getEString(), "name", null, 0, 1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getConference_Days(), this.getDay(), null, "days", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getConference_Locations(), this.getLocation(), null, "locations", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getConference_Days(), this.getDay(), null, "days", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getConference_Locations(), this.getLocation(), null, "locations", null, 0, -1, Conference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(talkEClass, Talk.class, "Talk", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getTalk_Speakers(), this.getPerson(), this.getPerson_Talks(), "speakers", null, 0, -1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getTalk_Name(), ecorePackage.getEString(), "name", null, 0, 1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getTalk_Abstract(), ecorePackage.getEString(), "abstract", null, 0, 1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getTalk_Duration(), ecorePackage.getEInt(), "duration", null, 0, 1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getTalk_Subjects(), this.getSubject(), null, "subjects", null, 0, -1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getTalk_MakingOfStories(), theMakingOfPackage.getStory(), null, "makingOfStories", null, 0, -1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTalk_Subjects(), this.getSubject(), null, "subjects", null, 0, -1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTalk_MakingOfStories(), theMakingOfPackage.getStory(), null, "makingOfStories", null, 0, -1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTalk_Day(), this.getDay(), this.getDay_Talks(), "day", null, 0, 1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTalk_Location(), this.getLocation(), this.getLocation_Talks(), "location", null, 0, 1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getTalk_Time(), ecorePackage.getEString(), "time", null, 0, 1, Talk.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -580,7 +580,7 @@ public class ConferencePackageImpl extends EPackageImpl implements ConferencePac
 		initEReference(getPerson_Tracks(), this.getTrack(), this.getTrack_Animators(), "tracks", null, 0, -1, Person.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(trackEClass, Track.class, "Track", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getTrack_Talks(), this.getTalk(), null, "talks", null, 0, -1, Track.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTrack_Talks(), this.getTalk(), null, "talks", null, 0, -1, Track.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getTrack_Name(), ecorePackage.getEString(), "name", null, 0, 1, Track.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTrack_Animators(), this.getPerson(), this.getPerson_Tracks(), "animators", null, 0, -1, Track.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 

--- a/plugins/fr.obeo.conference/src/conference/impl/DayImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/DayImpl.java
@@ -28,11 +28,11 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.impl.DayImpl#getName <em>Name</em>}</li>
  *   <li>{@link conference.impl.DayImpl#getTalks <em>Talks</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/plugins/fr.obeo.conference/src/conference/impl/LocationImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/LocationImpl.java
@@ -28,11 +28,11 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.impl.LocationImpl#getName <em>Name</em>}</li>
  *   <li>{@link conference.impl.LocationImpl#getTalks <em>Talks</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/plugins/fr.obeo.conference/src/conference/impl/PersonImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/PersonImpl.java
@@ -29,13 +29,13 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.impl.PersonImpl#getTalks <em>Talks</em>}</li>
  *   <li>{@link conference.impl.PersonImpl#getName <em>Name</em>}</li>
  *   <li>{@link conference.impl.PersonImpl#getOrganisation <em>Organisation</em>}</li>
  *   <li>{@link conference.impl.PersonImpl#getTracks <em>Tracks</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/plugins/fr.obeo.conference/src/conference/impl/SubjectImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/SubjectImpl.java
@@ -18,11 +18,11 @@ import org.eclipse.emf.ecore.impl.EObjectImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.impl.SubjectImpl#getDescription <em>Description</em>}</li>
  *   <li>{@link conference.impl.SubjectImpl#isIsDone <em>Is Done</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/plugins/fr.obeo.conference/src/conference/impl/TalkImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/TalkImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.impl.TalkImpl#getSpeakers <em>Speakers</em>}</li>
  *   <li>{@link conference.impl.TalkImpl#getName <em>Name</em>}</li>
@@ -44,7 +45,6 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link conference.impl.TalkImpl#getLocation <em>Location</em>}</li>
  *   <li>{@link conference.impl.TalkImpl#getTime <em>Time</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -280,7 +280,7 @@ public class TalkImpl extends EObjectImpl implements Talk {
 	 */
 	public EList<Subject> getSubjects() {
 		if (subjects == null) {
-			subjects = new EObjectContainmentEList<Subject>(Subject.class, this, ConferencePackage.TALK__SUBJECTS);
+			subjects = new EObjectContainmentEList.Resolving<Subject>(Subject.class, this, ConferencePackage.TALK__SUBJECTS);
 		}
 		return subjects;
 	}
@@ -292,7 +292,7 @@ public class TalkImpl extends EObjectImpl implements Talk {
 	 */
 	public EList<Story> getMakingOfStories() {
 		if (makingOfStories == null) {
-			makingOfStories = new EObjectContainmentEList<Story>(Story.class, this, ConferencePackage.TALK__MAKING_OF_STORIES);
+			makingOfStories = new EObjectContainmentEList.Resolving<Story>(Story.class, this, ConferencePackage.TALK__MAKING_OF_STORIES);
 		}
 		return makingOfStories;
 	}

--- a/plugins/fr.obeo.conference/src/conference/impl/TrackImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/impl/TrackImpl.java
@@ -30,12 +30,12 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.impl.TrackImpl#getTalks <em>Talks</em>}</li>
  *   <li>{@link conference.impl.TrackImpl#getName <em>Name</em>}</li>
  *   <li>{@link conference.impl.TrackImpl#getAnimators <em>Animators</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -106,7 +106,7 @@ public class TrackImpl extends EObjectImpl implements Track {
 	 */
 	public EList<Talk> getTalks() {
 		if (talks == null) {
-			talks = new EObjectContainmentEList<Talk>(Talk.class, this, ConferencePackage.TRACK__TALKS);
+			talks = new EObjectContainmentEList.Resolving<Talk>(Talk.class, this, ConferencePackage.TRACK__TALKS);
 		}
 		return talks;
 	}

--- a/plugins/fr.obeo.conference/src/conference/makingOf/Attitude.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/Attitude.java
@@ -118,6 +118,8 @@ public enum Attitude implements Enumerator {
 	 * Returns the '<em><b>Attitude</b></em>' literal with the specified literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @param literal the literal.
+	 * @return the matching enumerator or <code>null</code>.
 	 * @generated
 	 */
 	public static Attitude get(String literal) {
@@ -134,6 +136,8 @@ public enum Attitude implements Enumerator {
 	 * Returns the '<em><b>Attitude</b></em>' literal with the specified name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @param name the name.
+	 * @return the matching enumerator or <code>null</code>.
 	 * @generated
 	 */
 	public static Attitude getByName(String name) {
@@ -150,6 +154,8 @@ public enum Attitude implements Enumerator {
 	 * Returns the '<em><b>Attitude</b></em>' literal with the specified integer value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @param value the integer value.
+	 * @return the matching enumerator or <code>null</code>.
 	 * @generated
 	 */
 	public static Attitude get(int value) {

--- a/plugins/fr.obeo.conference/src/conference/makingOf/Day.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/Day.java
@@ -13,13 +13,13 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.Day#getName <em>Name</em>}</li>
  *   <li>{@link conference.makingOf.Day#getTasks <em>Tasks</em>}</li>
  *   <li>{@link conference.makingOf.Day#getIdeas <em>Ideas</em>}</li>
  *   <li>{@link conference.makingOf.Day#getParticipants <em>Participants</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.makingOf.MakingOfPackage#getDay()
  * @model
@@ -63,7 +63,7 @@ public interface Day extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Tasks</em>' containment reference list.
 	 * @see conference.makingOf.MakingOfPackage#getDay_Tasks()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Task> getTasks();
@@ -79,7 +79,7 @@ public interface Day extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Ideas</em>' containment reference list.
 	 * @see conference.makingOf.MakingOfPackage#getDay_Ideas()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Task> getIdeas();
@@ -95,7 +95,7 @@ public interface Day extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Participants</em>' containment reference list.
 	 * @see conference.makingOf.MakingOfPackage#getDay_Participants()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Participant> getParticipants();

--- a/plugins/fr.obeo.conference/src/conference/makingOf/Participant.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/Participant.java
@@ -13,12 +13,12 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.Participant#getAge <em>Age</em>}</li>
  *   <li>{@link conference.makingOf.Participant#getPerson <em>Person</em>}</li>
  *   <li>{@link conference.makingOf.Participant#getAttitude <em>Attitude</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.makingOf.MakingOfPackage#getParticipant()
  * @model

--- a/plugins/fr.obeo.conference/src/conference/makingOf/Story.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/Story.java
@@ -13,11 +13,11 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.Story#getDays <em>Days</em>}</li>
  *   <li>{@link conference.makingOf.Story#getName <em>Name</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.makingOf.MakingOfPackage#getStory()
  * @model
@@ -35,7 +35,7 @@ public interface Story extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Days</em>' containment reference list.
 	 * @see conference.makingOf.MakingOfPackage#getStory_Days()
-	 * @model containment="true"
+	 * @model containment="true" resolveProxies="true"
 	 * @generated
 	 */
 	EList<Day> getDays();

--- a/plugins/fr.obeo.conference/src/conference/makingOf/Task.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/Task.java
@@ -13,11 +13,11 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.Task#getName <em>Name</em>}</li>
  *   <li>{@link conference.makingOf.Task#getIsInvolved <em>Is Involved</em>}</li>
  * </ul>
- * </p>
  *
  * @see conference.makingOf.MakingOfPackage#getTask()
  * @model

--- a/plugins/fr.obeo.conference/src/conference/makingOf/impl/DayImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/impl/DayImpl.java
@@ -29,13 +29,13 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.impl.DayImpl#getName <em>Name</em>}</li>
  *   <li>{@link conference.makingOf.impl.DayImpl#getTasks <em>Tasks</em>}</li>
  *   <li>{@link conference.makingOf.impl.DayImpl#getIdeas <em>Ideas</em>}</li>
  *   <li>{@link conference.makingOf.impl.DayImpl#getParticipants <em>Participants</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -137,7 +137,7 @@ public class DayImpl extends EObjectImpl implements Day {
 	 */
 	public EList<Task> getTasks() {
 		if (tasks == null) {
-			tasks = new EObjectContainmentEList<Task>(Task.class, this, MakingOfPackage.DAY__TASKS);
+			tasks = new EObjectContainmentEList.Resolving<Task>(Task.class, this, MakingOfPackage.DAY__TASKS);
 		}
 		return tasks;
 	}
@@ -149,7 +149,7 @@ public class DayImpl extends EObjectImpl implements Day {
 	 */
 	public EList<Task> getIdeas() {
 		if (ideas == null) {
-			ideas = new EObjectContainmentEList<Task>(Task.class, this, MakingOfPackage.DAY__IDEAS);
+			ideas = new EObjectContainmentEList.Resolving<Task>(Task.class, this, MakingOfPackage.DAY__IDEAS);
 		}
 		return ideas;
 	}
@@ -161,7 +161,7 @@ public class DayImpl extends EObjectImpl implements Day {
 	 */
 	public EList<Participant> getParticipants() {
 		if (participants == null) {
-			participants = new EObjectContainmentEList<Participant>(Participant.class, this, MakingOfPackage.DAY__PARTICIPANTS);
+			participants = new EObjectContainmentEList.Resolving<Participant>(Participant.class, this, MakingOfPackage.DAY__PARTICIPANTS);
 		}
 		return participants;
 	}

--- a/plugins/fr.obeo.conference/src/conference/makingOf/impl/MakingOfPackageImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/impl/MakingOfPackageImpl.java
@@ -360,12 +360,12 @@ public class MakingOfPackageImpl extends EPackageImpl implements MakingOfPackage
 		// Initialize classes and features; add operations and parameters
 		initEClass(dayEClass, Day.class, "Day", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getDay_Name(), ecorePackage.getEString(), "name", null, 0, 1, Day.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getDay_Tasks(), this.getTask(), null, "tasks", null, 0, -1, Day.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getDay_Ideas(), this.getTask(), null, "ideas", null, 0, -1, Day.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getDay_Participants(), this.getParticipant(), null, "participants", null, 0, -1, Day.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getDay_Tasks(), this.getTask(), null, "tasks", null, 0, -1, Day.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getDay_Ideas(), this.getTask(), null, "ideas", null, 0, -1, Day.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getDay_Participants(), this.getParticipant(), null, "participants", null, 0, -1, Day.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(storyEClass, Story.class, "Story", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getStory_Days(), this.getDay(), null, "days", null, 0, -1, Story.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getStory_Days(), this.getDay(), null, "days", null, 0, -1, Story.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getStory_Name(), ecorePackage.getEString(), "name", null, 0, 1, Story.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(taskEClass, Task.class, "Task", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);

--- a/plugins/fr.obeo.conference/src/conference/makingOf/impl/ParticipantImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/impl/ParticipantImpl.java
@@ -22,12 +22,12 @@ import org.eclipse.emf.ecore.impl.EObjectImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.impl.ParticipantImpl#getAge <em>Age</em>}</li>
  *   <li>{@link conference.makingOf.impl.ParticipantImpl#getPerson <em>Person</em>}</li>
  *   <li>{@link conference.makingOf.impl.ParticipantImpl#getAttitude <em>Attitude</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/plugins/fr.obeo.conference/src/conference/makingOf/impl/StoryImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/impl/StoryImpl.java
@@ -29,11 +29,11 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.impl.StoryImpl#getDays <em>Days</em>}</li>
  *   <li>{@link conference.makingOf.impl.StoryImpl#getName <em>Name</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
@@ -94,7 +94,7 @@ public class StoryImpl extends EObjectImpl implements Story {
 	 */
 	public EList<Day> getDays() {
 		if (days == null) {
-			days = new EObjectContainmentEList<Day>(Day.class, this, MakingOfPackage.STORY__DAYS);
+			days = new EObjectContainmentEList.Resolving<Day>(Day.class, this, MakingOfPackage.STORY__DAYS);
 		}
 		return days;
 	}

--- a/plugins/fr.obeo.conference/src/conference/makingOf/impl/TaskImpl.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/impl/TaskImpl.java
@@ -25,11 +25,11 @@ import org.eclipse.emf.ecore.util.EObjectResolvingEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link conference.makingOf.impl.TaskImpl#getName <em>Name</em>}</li>
  *   <li>{@link conference.makingOf.impl.TaskImpl#getIsInvolved <em>Is Involved</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */

--- a/plugins/fr.obeo.conference/src/conference/makingOf/util/MakingOfSwitch.java
+++ b/plugins/fr.obeo.conference/src/conference/makingOf/util/MakingOfSwitch.java
@@ -47,7 +47,7 @@ public class MakingOfSwitch<T> extends Switch<T> {
 	 * Checks whether this is a switch for the given package.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @parameter ePackage the package in question.
+	 * @param ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
 	 */

--- a/plugins/fr.obeo.conference/src/conference/util/ConferenceSwitch.java
+++ b/plugins/fr.obeo.conference/src/conference/util/ConferenceSwitch.java
@@ -47,7 +47,7 @@ public class ConferenceSwitch<T> extends Switch<T> {
 	 * Checks whether this is a switch for the given package.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @parameter ePackage the package in question.
+	 * @param ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
 	 */


### PR DESCRIPTION
- Change conference.genmodel/Containment_Proxies to true in order that
  resolveProxies setting for containment references is respected. This is
  required to control the referenced objects.
- Regenerate conference MetaModel
